### PR TITLE
Remove deprecated `register`  keyword

### DIFF
--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrix4.inl
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrix4.inl
@@ -468,7 +468,7 @@ namespace Ogre
             dst3 = tmp1.val[3];                     \
         }
 
-        register ArrayReal m0, m1, m2, m3;
+        ArrayReal m0, m1, m2, m3;
 
         _MM_TRANSPOSE4_SRC_DST_PS(
                             this->mChunkBase[0], this->mChunkBase[1],

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrixAf4x3.inl
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrixAf4x3.inl
@@ -543,7 +543,7 @@ namespace Ogre
             dst2 = tmp1.val[2];                     \
             dst3 = tmp1.val[3];                     \
         }
-        register ArrayReal m0, m1, m2, m3;
+        ArrayReal m0, m1, m2, m3;
 
         _MM_TRANSPOSE4_SRC_DST_PS(
                             this->mChunkBase[0], this->mChunkBase[1],
@@ -597,7 +597,7 @@ namespace Ogre
     //-----------------------------------------------------------------------------------
     inline void ArrayMatrixAf4x3::streamToAoS( SimpleMatrixAf4x3 * RESTRICT_ALIAS _dst ) const
     {
-        register ArrayReal dst0, dst1, dst2, dst3;
+        ArrayReal dst0, dst1, dst2, dst3;
         Real *dst = reinterpret_cast<Real*>( _dst );
 
         _MM_TRANSPOSE4_SRC_DST_PS(

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrix4.inl
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrix4.inl
@@ -472,7 +472,7 @@ namespace Ogre
             (dst2) = _mm_shuffle_ps(tmp2, tmp3, 0x88);              \
             (dst3) = _mm_shuffle_ps(tmp2, tmp3, 0xDD);              \
         }
-        register ArrayReal m0, m1, m2, m3;
+        ArrayReal m0, m1, m2, m3;
 
         _MM_TRANSPOSE4_SRC_DST_PS(
                             this->mChunkBase[0], this->mChunkBase[1],

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrixAf4x3.inl
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrixAf4x3.inl
@@ -550,7 +550,7 @@ namespace Ogre
             (dst2) = _mm_shuffle_ps(tmp2, tmp3, 0x88);              \
             (dst3) = _mm_shuffle_ps(tmp2, tmp3, 0xDD);              \
         }
-        register ArrayReal m0, m1, m2, m3;
+        ArrayReal m0, m1, m2, m3;
 
         _MM_TRANSPOSE4_SRC_DST_PS(
                             this->mChunkBase[0], this->mChunkBase[1],
@@ -604,7 +604,7 @@ namespace Ogre
     //-----------------------------------------------------------------------------------
     inline void ArrayMatrixAf4x3::streamToAoS( SimpleMatrixAf4x3 * RESTRICT_ALIAS _dst ) const
     {
-        register __m128 dst0, dst1, dst2, dst3;
+        __m128 dst0, dst1, dst2, dst3;
         Real *dst = reinterpret_cast<Real*>( _dst );
 
         _MM_TRANSPOSE4_SRC_DST_PS(

--- a/OgreMain/include/OgreMemorySTLAllocator.h
+++ b/OgreMain/include/OgreMemorySTLAllocator.h
@@ -127,7 +127,7 @@ namespace Ogre
         {
                         (void)ptr;
             // convert request to bytes
-            register size_type sz = count*sizeof( T );
+            size_type sz = count*sizeof( T );
             pointer p  = static_cast<pointer>(AllocPolicy::allocateBytes(sz));
             return p;
         }


### PR DESCRIPTION
We're having Visual Studio Warnings on ign-sensors3 Windows complaining about that `register` keyword is now deprecated (Check [microsoft explanation](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5033?view=msvc-170))

This PR removes applies the same fix used in this ogre-next commit: https://github.com/OGRECave/ogre-next/commit/32ba36e8749bde782ccacfff67be1c3261c6cf81

Reference build: https://build.osrfoundation.org/job/ign_sensors-ign-3-win/63/

Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>